### PR TITLE
Fix persisting directory and launcher

### DIFF
--- a/flightgear.sh
+++ b/flightgear.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-FG_ROOT=/app/share/flightgear FG_AIRCRAFT=$XDG_DATA_HOME/fgfs/Aircraft/ FG_SCENERY=$XDG_DATA_HOME/fgfs/Scenery fgfs --launcher "$@"

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -12,7 +12,7 @@ finish-args:
 - --device=all
 - --socket=pulseaudio
 - --share=network
-- --persist=~/.fgfs/
+- --persist=.fgfs
 cleanup:
 - /include
 - /lib/pkgconfig

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -43,6 +43,18 @@ modules:
 - shared-modules/glu/glu-9.0.0.json
 - shared-modules/glew/glew.json
 
+
+- name: freeglut
+  buildsystem: cmake
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=Release
+  - -DFREEGLUT_BUILD_DEMOS=OFF
+  - -DFREEGLUT_BUILD_SHARED_LIBS=ON
+  sources:
+  - type: archive
+    url: https://sourceforge.net/projects/freeglut/files/freeglut/3.2.1/freeglut-3.2.1.tar.gz
+    sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
+
 - name: mesa
   config-opts:
   - --enable-osmesa

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -13,6 +13,12 @@ finish-args:
 - --socket=pulseaudio
 - --share=network
 - --persist=.fgfs
+# As of http://wiki.flightgear.org/$FG_HOME, "$FG_HOME is a notable place were
+# FlightGear data is written to, contrary to $FG_ROOT, which is generally read-only."
+# This means that it's safe to store the default built-in flightgear-data under /app,
+# which is writable but non-persistent.
+# The FG_ROOT can still be changed by passing the --fg-root option when calling flatpak run.
+- --env=FG_ROOT=/app/share/flightgear
 cleanup:
 - /include
 - /lib/pkgconfig
@@ -140,12 +146,13 @@ modules:
     sha256: 5acbd008a31119877fefbdfae912ae8495f716288731c91add487fc98828fe53
   - type: file
     path: org.flightgear.FlightGear.appdata.xml
-  - type: file
-    path: flightgear.sh
+  - type: script
+    commands:
+    - fgfs --launcher "$@"
+    dest-filename: flightgear.sh
   build-commands:
   - install -Dm644 ../org.flightgear.FlightGear.appdata.xml /app/share/appdata/org.flightgear.FlightGear.appdata.xml
-  - install -Dm744 ../flightgear.sh /app/bin/flightgear.sh
-  - chmod +x /app/bin/flightgear.sh
+  - install -Dm755 ../flightgear.sh /app/bin/flightgear.sh
   post-install:
   - desktop-file-edit --set-key=Exec --set-value=flightgear.sh /app/share/applications/org.flightgear.FlightGear.desktop
   - desktop-file-edit --set-key=StartupWMClass --set-value=osgViewer /app/share/applications/org.flightgear.FlightGear.desktop

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -133,7 +133,7 @@ modules:
 - shared-modules/udev/udev-175.json
 
 - name: flightgear
-  buildsystem: cmake-ninja
+  buildsystem: cmake
   config-opts:
   - -DENABLE_QT=ON
   - -DCMAKE_BUILD_TYPE=Release

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -39,8 +39,9 @@ modules:
     sha256: 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
   cleanup:
   - /include
-  
+
 - shared-modules/glu/glu-9.0.0.json
+- shared-modules/glew/glew.json
 
 - name: mesa
   config-opts:
@@ -54,14 +55,14 @@ modules:
   config-opts:
   - --disable-everything
   - --enable-shared
-  # Enough to run the base game, might need extending for mod content 
+  # Enough to run the base game, might need extending for mod content
   - --enable-decoder=bink,binkaudio_rdft,mp3,pcm_s16le,vorbis
   - --enable-demuxer=bink,mp3,ogg,pcm_s16le,wav
   sources:
   - type: archive
     url: https://ffmpeg.org/releases/ffmpeg-4.1.tar.bz2
     sha256: b684fb43244a5c4caae652af9022ed5d85ce15210835bce054a33fb26033a1a5
-    
+
 - name: openscenegraph
   buildsystem: cmake-ninja
   config-opts:
@@ -74,7 +75,7 @@ modules:
     commands:
     - sed 's|SET(LIB_POSTFIX "64" CACHE|SET(LIB_POSTFIX "" CACHE|' -i CMakeLists.txt
     - sed 's|DGifCloseFile(giffile)|DGifCloseFile(giffile,0)|' -i src/osgPlugins/gif/ReaderWriterGIF.cpp
-    
+
 - name: simgear
   builddir: true
   buildsystem: cmake-ninja
@@ -87,19 +88,19 @@ modules:
     sha256: c8b094a8c5045362848781f72117dbec424472bf6b9dd135dfe43f9b915781a4
   - type: patch
     path: boost-1.69.patch
-    
+
 - name: xmu
   sources:
   - type: archive
     url: https://www.x.org/archive//individual/lib/libXmu-1.1.2.tar.bz2
     sha256: 756edc7c383254eef8b4e1b733c3bf1dc061b523c9f9833ac7058378b8349d0b
-    
+
 - name: plib
   sources:
   - type: archive
     url: http://plib.sourceforge.net/dist/plib-1.8.5.tar.gz
     sha256: 485b22bf6fdc0da067e34ead5e26f002b76326f6371e2ae006415dea6a380a32
-    
+
 - name: flightgear-data
   buildsystem: simple
   sources:
@@ -110,9 +111,9 @@ modules:
   build-commands:
   - mkdir --parents /app/share/flightgear
   - mv fgdata/* /app/share/flightgear/
-    
+
 - shared-modules/udev/udev-175.json
- 
+
 - name: flightgear
   buildsystem: cmake-ninja
   config-opts:


### PR DESCRIPTION
As explained here: https://docs.flatpak.org/en/latest/flatpak-command-reference.html (also a nice explanation [here](https://github.com/flatpak/flatpak-docs/issues/109#issuecomment-377268350)) using the prefix `~/` is not needed when specifying a persisting directory, it is somehow implicit:

> ... For instance making `.myapp` persistent would make `~/.myapp` in the sandbox a bind mount to `~/.var/app/org.my.App/.myapp`, thus allowing an unmodified application to save data in the per-application location.

Otherwise an additional directory called `~` will be created in the filesystem path `$HOME/.var/app/org.my.App/.myapp`. I think this is not what is intended.

Also, no need to use `$XDG_DATA_HOME`, it should be simpler to directly use the persisting directory. In addition the folders `fgfs` (without initial dot) were not existing.