### PR TITLE
appdata: Migrate to metainfo

### DIFF
--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
-<!-- HOUSEKEEPING, REMOVE THIS COMMENT WHEN THIS GOES UPSTREAM
-BugReportURL: https://sourceforge.net/p/fgrun/support-requests/9/
-SentUpstream: 2014-09-17
--->
-<component type="desktop">
+<!-- FlightGear already has a metainfo file in their main repository, but to -->
+<!-- avoid too much back-and-forth changes to their one when screenshots or  -->
+<!-- releases are done, their metainfo file is replaced with this one.       -->
+<component type="desktop-application">
 	<id>org.flightgear.FlightGear</id>
 	<name>FlightGear</name>
 	<summary>A free and highly sophisticated flight simulator</summary>

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -129,14 +129,13 @@ modules:
     url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/flightgear-2020.3.8.tar.bz2
     sha256: 5d70ea859f6747e1704372dab997bc886c4e8e5c835c3ac4b63eb50501950d87
   - type: file
-    path: org.flightgear.FlightGear.appdata.xml
+    path: org.flightgear.FlightGear.metainfo.xml
   - type: script
     commands:
     - fgfs --launcher "$@"
     dest-filename: flightgear.sh
-  build-commands:
-  - install -Dm644 ../org.flightgear.FlightGear.appdata.xml /app/share/appdata/org.flightgear.FlightGear.appdata.xml
-  - install -Dm755 ../flightgear.sh /app/bin/flightgear.sh
   post-install:
+  - install -Dm644 ../org.flightgear.FlightGear.metainfo.xml /app/share/metainfo/org.flightgear.FlightGear.metainfo.xml
+  - install -Dm755 ../flightgear.sh /app/bin/flightgear.sh
   - desktop-file-edit --set-key=Exec --set-value=flightgear.sh /app/share/applications/org.flightgear.FlightGear.desktop
   - desktop-file-edit --set-key=StartupWMClass --set-value=osgViewer /app/share/applications/org.flightgear.FlightGear.desktop


### PR DESCRIPTION
Metainfo is the preferred name and location for appdata files.
Since flightgear already ships a metainfo file, and those are
preferred over appdata ones, the computed data in the built
flatpak were the one from the upstream's metainfo, not our
appdata with all the screenshots. So now the upstream metainfo
is replaced by the one in this flathub repository, which means
the new screenshots are now shown on both the flathub.org app
page and in GNOME Software et al.