### PR TITLE
Revert "appdata: Drop comma from description in thousands numbering"

### DIFF
--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -12,7 +12,7 @@
 	<metadata_license>CC0-1.0</metadata_license>
 	<description>
 		<p>FlightGear allows you to control over 400 aircraft, small and large in a range of situations, types of weather, seasons, day and night cycle. This includes single-engine propeller aircraft, large 4-engine passenger liners, experimental aircraft, classic and vintage aircraft and helicopters.</p>
-		<p>The FlightGear landscape covers the entire world and is downloaded as you fly. Visit any of the 20000 airports with an accurate representation of airport buildings on many of the larger, international airports.</p>
+		<p>The FlightGear landscape covers the entire world and is downloaded as you fly. Visit any of the 20,000 airports with an accurate representation of airport buildings on many of the larger, international airports.</p>
 		<p>Most popular flight control hardware, such as yokes and sticks are supported. Multiple monitor setup and multiplayer is also featured.</p>
 	</description>
 	<description xml:lang="pt_BR">


### PR DESCRIPTION
This reverts commit 31881bd1c3a5a4ec352be2f28fa2f8a9eefe3198.

It seems like I made a mistake: the spaces were already removed, it's
just that the (still) broken upstream metainfo file was used instead
(see previous commit about appdata to metainfo conversion), where it
didn't have the commit that fixed the spacing.