### PR TITLE
Update to 2020.3.9

### DIFF
--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -125,6 +125,7 @@
 	<url type="translate">https://wiki.flightgear.org/Howto:Translate_FlightGear</url>
 	<releases>
 		<!-- When updating flightgear, add a new line below (don't remove the older ones) and sort them newest-first -->
+		<release date="2020-06-11" version="2020.3.9" />
 		<release date="2021-03-25" version="2020.3.8" />
 		<release date="2021-01-24" version="2020.3.6" />
 		<release date="2020-12-19" version="2020.3.5" />

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -4,14 +4,6 @@ runtime: org.kde.Platform
 # version as well, by checking which version of the freedesktop-sdk this KDE runtime depends on.
 runtime-version: 5.15
 sdk: org.kde.Sdk
-# ffmpeg might be used by libflite, the audio-synthesis library used by flightgear and provided by the KDE runtime.
-# As of https://invent.kde.org/packaging/flatpak-kde-runtime/-/commit/ec8fab8796126c8e3fbeaa9ed8d78ebfd12d2198,
-# the KDE runtime lets application depend on the ffmpeg runtime if needed (for libflite)
-add-extensions:
-  - org.freedesktop.Platform.ffmpeg-full:
-      - directory: lib/ffmpeg
-      - version: 20.08
-      - add-ld-path: .
 command: flightgear.sh
 rename-icon: flightgear
 finish-args:

--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -80,8 +80,8 @@ modules:
       - -DENABLE_TESTS=OFF
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/simgear-2020.3.8.tar.bz2
-        sha256: 51771657d30fbbb73e425163ae1c6d43aaee01cc6e2ad7b0c2986ee2db797567
+        url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/simgear-2020.3.9.tar.bz2
+        sha256: 5da4688e049389793bed7b2655399f1bc0109c7bb06389de6684719639424e6c
         x-checker-data:
           type: anitya
           project-id: 9667
@@ -122,8 +122,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/FlightGear-2020.3.8-data.txz
-        sha256: fca16e987464991bec53f2f58b5d631bf29baa86e73843fb9789723cc287c9c0
+        url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/FlightGear-2020.3.9-data.txz
+        sha256: ffff439931bd4c7e8ad12d1cbbeffc83c6d1a4e64b0857df43d420f9efbdb76c
         dest: fgdata
         x-checker-data:
           type: anitya
@@ -147,8 +147,8 @@ modules:
     builddir: true
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/flightgear-2020.3.8.tar.bz2
-        sha256: 5d70ea859f6747e1704372dab997bc886c4e8e5c835c3ac4b63eb50501950d87
+        url: https://downloads.sourceforge.net/project/flightgear/release-2020.3/flightgear-2020.3.9.tar.bz2
+        sha256: d71f6c6804dae4d9c3e0c8e25dcf76973d19d747c0b051a0174703a238ac138e
         x-checker-data:
           type: anitya
           project-id: 9716


### PR DESCRIPTION
I was suscribed to the sourceforge release RSS so I saw that a new release was available. It seems like [Anitya is watching the RSS too](https://release-monitoring.org/project/9716/), but it must be broken because it "updated" today but hasn't noticed a new version is out. But to report it I need a fedora account, which I don't have, so too bad.