### PR TITLE
Revert "Update org.kde.Sdk to version 6.6"

### DIFF
--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -2,7 +2,7 @@ id: org.flightgear.FlightGear
 runtime: org.kde.Platform
 # When updating this version number, care must be taken to update the ffmpeg extension
 # version as well, by checking which version of the freedesktop-sdk this KDE runtime depends on.
-runtime-version: 6.6
+runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 command: flightgear.sh
 rename-icon: flightgear


### PR DESCRIPTION
Reverts flathub/org.flightgear.FlightGear#90, since the launcher apparently does not yet support Qt6.