### PR TITLE
Fix outdated links

### DIFF
--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -153,13 +153,11 @@
 		<name>The FlightGear Developers</name>
 	</developer>
 	<url type="homepage">https://www.flightgear.org/</url>
-	<url type="bugtracker">https://sourceforge.net/p/flightgear/codetickets/</url>
+	<url type="bugtracker">https://gitlab.com/flightgear/flightgear/-/issues/</url>
 	<url type="faq">https://wiki.flightgear.org/Frequently_asked_questions</url>
 	<url type="help">https://flightgear.sourceforge.net/getstart-en/getstart-en.html</url>
-	<url type="donation">https://store.flightgear.org/</url>
 	<url type="translate">https://wiki.flightgear.org/Howto:Translate_FlightGear</url>
-	<url type="contact">https://www.flightgear.org/flying/</url>
-	<url type="vcs-browser">https://sourceforge.net/p/flightgear/flightgear/ci/next/tree/</url>
+	<url type="vcs-browser">https://gitlab.com/flightgear/flightgear/</url>
 	<url type="contribute">https://wiki.flightgear.org/Portal:Developer</url>
 	<launchable type="desktop-id">org.flightgear.FlightGear.desktop</launchable>
 	<!-- When updating flightgear, add a new line below (don't remove the older ones) and sort them newest-first -->


### PR DESCRIPTION
The FlightGear project has moved to GitLab, so the links to SourceForge are no longer correct for viewing the source code or the bug tracker. Additionally, the donate link points to a now-defunct store page, so it has been removed. 