### PR TITLE
Follow the quality guidelines

### DIFF
--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -7,7 +7,7 @@
 	<project_license>GPL-2.0</project_license>
 	<id>org.flightgear.FlightGear</id>
 	<name>FlightGear</name>
-	<summary>Free open-source flight simulator</summary>
+	<summary>Free and open-source flight simulator</summary>
 	<summary xml:lang="pt_BR">Simulador de voo gratuito de código aberto</summary>
 	<summary xml:lang="es">Simulador de vuelo gratuito de código abierto</summary>
 	<summary xml:lang="it">Simulatore di volo open source gratuito</summary>

--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -7,10 +7,10 @@
 	<project_license>GPL-2.0</project_license>
 	<id>org.flightgear.FlightGear</id>
 	<name>FlightGear</name>
-	<summary>A free and highly sophisticated flight simulator</summary>
-	<summary xml:lang="pt_BR">Um simulador de voo gratuito e altamente sofisticado</summary>
-	<summary xml:lang="es">Un simulador de vuelo gratuito y altamente sofisticado</summary>
-	<summary xml:lang="it">Un simulatore di volo gratuito e altamente sofisticato</summary>
+	<summary>Free open-source flight simulator</summary>
+	<summary xml:lang="pt_BR">Simulador de voo gratuito de código aberto</summary>
+	<summary xml:lang="es">Simulador de vuelo gratuito de código abierto</summary>
+	<summary xml:lang="it">Simulatore di volo open source gratuito</summary>
 	<description>
 		<p>FlightGear allows you to control over 400 aircraft, small and large in a range of
 			situations, types of weather, seasons, day and night cycle. This includes single-engine
@@ -61,6 +61,10 @@
 			levette. Sono
 			presenti anche impostazioni per monitor multipli e multiplayer.</p>
 	</description>
+	<branding>
+  		<color type="primary" scheme_preference="light">#427ec0</color>
+  		<color type="primary" scheme_preference="dark">#0e62bf</color>
+	</branding>
 	<!-- All the screenshots are licensed under CC-BY-SA 4.0 and available in the FlightGear wiki.
 	To find a lot of high quality FlightGear screenshots, see
 	https://wiki.flightgear.org/Category:Screenshots_at_high_settings,

--- a/org.flightgear.FlightGear.metainfo.xml
+++ b/org.flightgear.FlightGear.metainfo.xml
@@ -8,9 +8,9 @@
 	<id>org.flightgear.FlightGear</id>
 	<name>FlightGear</name>
 	<summary>Free and open-source flight simulator</summary>
-	<summary xml:lang="pt_BR">Simulador de voo gratuito de código aberto</summary>
-	<summary xml:lang="es">Simulador de vuelo gratuito de código abierto</summary>
-	<summary xml:lang="it">Simulatore di volo open source gratuito</summary>
+	<summary xml:lang="pt_BR">Simulador de voo gratuito e de código aberto</summary>
+	<summary xml:lang="es">Simulador de vuelo gratuito y de código abierto</summary>
+	<summary xml:lang="it">Simulatore di volo gratuito e open-source</summary>
 	<description>
 		<p>FlightGear allows you to control over 400 aircraft, small and large in a range of
 			situations, types of weather, seasons, day and night cycle. This includes single-engine


### PR DESCRIPTION
@AsciiWolf Sorry for the ping, does this look correct?

Unfortunately I can't do anything about the warning for **App Icon** "Doesn't fill too much or too little of the canvas"...

This PR tries to fix the following warnings in **App Listing Quality**:

**Branding** "Has primary brand colors"
**Branding** "Good primary brand colors"
**Summary** "Shorter than 35 characters"
**Summary** "Doesn't start with an article"