### PR TITLE
Second Attempt at Fixing the Taskbar Icon

### DIFF
--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -152,4 +152,4 @@ modules:
       - install -Dm644 ../org.flightgear.FlightGear.metainfo.xml /app/share/metainfo/org.flightgear.FlightGear.metainfo.xml
       - install -Dm755 ../flightgear.sh /app/bin/flightgear.sh
       - desktop-file-edit --set-key=Exec --set-value=flightgear.sh /app/share/applications/org.flightgear.FlightGear.desktop
-      - desktop-file-edit --set-key=StartupWMClass --set-value=fgfs /app/share/applications/org.flightgear.FlightGear.desktop
+      - desktop-file-edit --set-key=StartupWMClass --set-value=FlightGear /app/share/applications/org.flightgear.FlightGear.desktop


### PR DESCRIPTION
FlightGear uses two separate window instances - one for the launcher and one for the simulator. I'm assuming that you are not going to see the actual simulator taskbar icon often so I'm trying to fix the launcher icon only.