### PR TITLE
Update post-install Step

### DIFF
--- a/org.flightgear.FlightGear.yaml
+++ b/org.flightgear.FlightGear.yaml
@@ -153,3 +153,4 @@ modules:
       - install -Dm755 ../flightgear.sh /app/bin/flightgear.sh
       - desktop-file-edit --set-key=Exec --set-value=flightgear.sh /app/share/applications/org.flightgear.FlightGear.desktop
       - desktop-file-edit --set-key=StartupWMClass --set-value=FlightGear /app/share/applications/org.flightgear.FlightGear.desktop
+      - desktop-file-edit --set-key=Name --set-value="FlightGear" /app/share/applications/org.flightgear.FlightGear.desktop


### PR DESCRIPTION
This should fix the following warning if FlightGear is launched from the Terminal:

`0,18 [WARN]:gui        QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix`